### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GoFlow executes your tasks on an array of workers by uniformly distributing the 
 Install GoFlow
 ```sh
 go mod init myflow
-go get github.com/s8sg/goflow
+go get github.com/s8sg/goflow@master
 ```
 
 ## Write First Flow


### PR DESCRIPTION
If you do not specify to use the master branch, go get will download the v0.1.0 version of goflow by default, which is a version that does not match the sample program.

if exec `go get github.com/s8sg/goflow`:
![image](https://user-images.githubusercontent.com/22193008/183311275-5ddf5b87-2382-42c8-93f7-c22d488fb94e.png)

if exec `go get github.com/s8sg/goflow@master`, it works well:
![image](https://user-images.githubusercontent.com/22193008/183311307-ac9c8779-3d9e-44e3-a896-97f8b5d81847.png)
![image](https://user-images.githubusercontent.com/22193008/183311308-a2755bbf-9d7e-4f14-a2e8-8157666f44f4.png)
