### PR TITLE
Bug fix for panic while executing node in parallel

### DIFF
--- a/core/redis-datastore/redis.go
+++ b/core/redis-datastore/redis.go
@@ -7,6 +7,9 @@ import (
 	faasflow "github.com/s8sg/goflow/core/sdk"
 )
 
+// ensure RedisDataStore impl all DataStore method declaration
+var _ faasflow.DataStore = (*RedisDataStore)(nil)
+
 type RedisDataStore struct {
 	bucketName  string
 	redisClient redis.UniversalClient
@@ -103,4 +106,8 @@ func (this *RedisDataStore) Cleanup() error {
 func getPath(bucket, key string) string {
 	fileName := fmt.Sprintf("%s.value", key)
 	return fmt.Sprintf("%s.%s", bucket, fileName)
+}
+
+func (this *RedisDataStore) CopyStore() (faasflow.DataStore, error) {
+	return &RedisDataStore{bucketName: this.bucketName, redisClient: this.redisClient}, nil
 }

--- a/core/redis-statestore/redis.go
+++ b/core/redis-statestore/redis.go
@@ -3,9 +3,11 @@ package RedisStateStore
 import (
 	"fmt"
 
-	faasflow "github.com/s8sg/goflow/core/sdk"
 	"github.com/go-redis/redis"
+	faasflow "github.com/s8sg/goflow/core/sdk"
 )
+
+var _ faasflow.StateStore = (*RedisStateStore)(nil)
 
 type RedisStateStore struct {
 	KeyPath    string
@@ -121,4 +123,7 @@ func (this *RedisStateStore) Cleanup() error {
 		rerr = err
 	}
 	return rerr
+}
+func (this *RedisStateStore) CopyStore() (faasflow.StateStore, error) {
+	return &RedisStateStore{KeyPath: this.KeyPath, RetryCount: this.RetryCount, rds: this.rds}, nil
 }

--- a/core/sdk/executor/default_datastore.go
+++ b/core/sdk/executor/default_datastore.go
@@ -2,7 +2,11 @@ package executor
 
 import (
 	"fmt"
+	faasflow "github.com/s8sg/goflow/core/sdk"
 )
+
+// ensure requestEmbedDataStore impl all DataStore method declaration
+var _ faasflow.DataStore = (*requestEmbedDataStore)(nil)
 
 // json to encode
 type requestEmbedDataStore struct {
@@ -59,4 +63,13 @@ func (rstore *requestEmbedDataStore) Del(key string) error {
 // Cleanup
 func (rstore *requestEmbedDataStore) Cleanup() error {
 	return nil
+}
+
+func (rstore *requestEmbedDataStore) CopyStore() (faasflow.DataStore, error) {
+
+	newStore := make(map[string][]byte)
+	for k, v := range rstore.store {
+		newStore[k] = v
+	}
+	return &requestEmbedDataStore{newStore}, nil
 }

--- a/core/sdk/executor/executor.go
+++ b/core/sdk/executor/executor.go
@@ -442,10 +442,9 @@ func (fexec *FlowExecutor) forwardState(currentNodeId string, nextNodeId string,
 	if fexec.isPaused() {
 		// if request is paused, store the partial state in the StateStore
 		fexec.log("[request `%s`] Request is paused, storing partial state for node: %s\n", fexec.id, nextNodeId)
-		err = fexec.storePartialState(partialState)
-		if err != nil {
-			return err
-		}
+		//fix issue#24
+		//when fexecn isPaused it show return it,without HandleNextNode method
+		return fexec.storePartialState(partialState)
 	}
 	err = fexec.executor.HandleNextNode(partialState)
 	if err != nil {

--- a/core/sdk/executor/executor.go
+++ b/core/sdk/executor/executor.go
@@ -957,9 +957,9 @@ func (fexec *FlowExecutor) initializeStore() (stateSDefined bool, dataSOverride 
 	if err != nil {
 		return
 	}
-
 	if stateS != nil {
-		fexec.stateStore = stateS
+		stateStore, _ := stateS.CopyStore()
+		fexec.stateStore = stateStore
 		stateSDefined = true
 		fexec.stateStore.Configure(fexec.flowName, fexec.id)
 		// If request is not partial initialize the stateStore
@@ -977,15 +977,15 @@ func (fexec *FlowExecutor) initializeStore() (stateSDefined bool, dataSOverride 
 		return
 	}
 	if dataS != nil {
-		fexec.dataStore = dataS
+		dataSotore, _ := dataS.CopyStore()
+		fexec.dataStore = dataSotore
 		dataSOverride = true
+		fexec.dataStore.Configure(fexec.flowName, fexec.id)
+		// If request is not partial initialize the dataStore
+		if !fexec.partial {
+			_ = fexec.dataStore.Init()
+		}
 	}
-	fexec.dataStore.Configure(fexec.flowName, fexec.id)
-	// If request is not partial initialize the dataStore
-	if !fexec.partial {
-		err = fexec.dataStore.Init()
-	}
-
 	return
 }
 

--- a/core/sdk/types.go
+++ b/core/sdk/types.go
@@ -14,6 +14,8 @@ type DataStore interface {
 	Del(key string) error
 	// Cleanup all the resources in DataStore
 	Cleanup() error
+	//Copy a DataSoure
+	CopyStore() (DataStore, error)
 }
 
 // StateStore for saving execution state
@@ -30,6 +32,8 @@ type StateStore interface {
 	Update(key string, oldValue string, newValue string) error
 	// Cleanup all the resources in StateStore (called only once in a request span)
 	Cleanup() error
+	//copy Store
+	CopyStore() (StateStore, error)
 }
 
 // EventHandler handle flow events


### PR DESCRIPTION
fix panic while server consume task  in parallel,(cause by executor#initializeStore() may use same dataStore or stateStore ,so that each excutor may use others keypath/bucketName)
solution: fix this bug by adding a new method call copyStore,while initializeStore, #copyStore can isolate each executor use it's owe keypath/bucketName, to avoid deleting other executor's data


issue: #20 