### PR TITLE
feat(ci): add ci for auto release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+name: Release
+on:
+  push:
+    tags-ignore:
+      - '**'
+    workflow_dispatch:
+
+jobs:
+  test: # Here we need to consider whether we need to ensure that the test passes before releasing
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        go: ['1.17', '1.18', '1.19']
+    name: Go ${{ matrix.go }} test
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Unit test
+        run: make
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: coverage.html
+          path: /tmp/coverage.html
+      - uses: actions/upload-artifact@v1
+        with:
+          name: coverage.html
+          path: /tmp/coverage.html
+#      - run: go test -race -v -coverprofile=profile.cov ./pkg/...
+#      - uses: codecov/codecov-action@v3.1.1
+#        with:
+#          file: ./profile.cov
+#          name: codecov-go
+  release:
+    runs-on: ubuntu-22.04
+    needs: [test]
+#    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Source checkout
+        uses: actions/checkout@v3
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        with:
+          dry_run: false
+          semantic_version: 18.0.1
+          extra_plugins: |
+            @semantic-release/exec@6.0.3

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    branches: ["main",{name: 'dev', prerelease: true},{name: 'alpha', prerelease: true},{name: 'beta', prerelease: true}],
+    plugins: [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/github"
+    ]
+};

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GoFlow executes your tasks on an array of workers by uniformly distributing the 
 Install GoFlow
 ```sh
 go mod init myflow
-go get github.com/s8sg/goflow@master
+go get github.com/s8sg/goflow
 ```
 
 ## Write First Flow


### PR DESCRIPTION
First of all sorry for the late reply.

In this pr, I hope to introduce an automated release process for the project, aiming to reduce the workload of the release, and at the same time make it easier for other developers to freely choose and switch between the development version, alpha version, beta version, and official version.

Below I will introduce the specific usage details of the automatic release introduced by this PR.

1. If someone wants to make a new feature, he should make a new branch which name can't be `dev`, `alpha` or `beta`.
2. Commit with the correct title which should follow the rule down below.
3. After development, he should make a pull request to merge the branch into the `dev` branch (or merge directly).
4. After merging, the release workflow will auto-release a new dev version of this project.
5. We can do the same progress to release the `main`, `alpha` or `beta` version.

| Commit message                                                                                                                                                                                   | Release type                                                                                                    |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
| `fix(pencil): stop graphite breaking when too much pressure applied`                                                                                                                             | ~~Patch~~ Fix Release                                                                                           |
| `feat(pencil): add 'graphiteWidth' option`                                                                                                                                                       | ~~Minor~~ Feature Release                                                                                       |
| `perf(pencil): remove graphiteWidth option`<br><br>`BREAKING CHANGE: The graphiteWidth option has been removed.`<br>`The default graphite width of 10mm is always used for performance reasons.` | ~~Major~~ Breaking Release <br /> (Note that the `BREAKING CHANGE: ` token must be in the footer of the commit) |

Thanks for your review ❤.

Best regards,
Asjdf