### PR TITLE
fix flow state update error

### DIFF
--- a/core/sdk/types.go
+++ b/core/sdk/types.go
@@ -28,6 +28,8 @@ type StateStore interface {
 	Set(key string, value string) error
 	// Get a value
 	Get(key string) (string, error)
+	// Increase the value of key with a given increment
+	Incr(key string, value int64) (int64, error)
 	// Compare and Update a value
 	Update(key string, oldValue string, newValue string) error
 	// Cleanup all the resources in StateStore (called only once in a request span)


### PR DESCRIPTION
Update the `counter` in the `statestore` using atomic operations to solve the issue of incorrect node indegree calculations in scenarios of concurrent updates from multiple workers.