### PR TITLE
Add api to export dag definition in json and Exporter

### DIFF
--- a/core/sdk/dag.go
+++ b/core/sdk/dag.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -339,6 +340,39 @@ func (this *Dag) GetNodes(dynamicOption string) []string {
 // IsExecutionFlow check if a dag doesn't use intermediate data
 func (this *Dag) IsExecutionFlow() bool {
 	return this.executionFlow
+}
+
+// GetDefinitionJson generate DAG definition as a json
+func (dag *Dag) GetDefinitionJson() ([]byte, error) {
+	root := &DagExporter{}
+
+	// Validate the dag
+	root.IsValid = true
+	err := dag.Validate()
+	if err != nil {
+		root.IsValid = false
+		root.ValidationError = err.Error()
+	}
+
+	exportDag(root, dag)
+	encoded, err := json.MarshalIndent(root, "", "    ")
+	return encoded, err
+}
+
+// GetDefinition represent DAG definition with exporter
+func (dag *Dag) GetDefinition() (*DagExporter, error) {
+	root := &DagExporter{}
+
+	// Validate the dag
+	root.IsValid = true
+	err := dag.Validate()
+	if err != nil {
+		root.IsValid = false
+		root.ValidationError = err.Error()
+	}
+
+	exportDag(root, dag)
+	return root, err
 }
 
 // inSlice check if a node belongs in a slice

--- a/core/sdk/definition.go
+++ b/core/sdk/definition.go
@@ -1,9 +1,5 @@
 package sdk
 
-import (
-	"encoding/json"
-)
-
 type DagExporter struct {
 	Id               string                   `json:"id"`
 	StartNode        string                   `json:"start-node"`
@@ -127,21 +123,4 @@ func exportDag(exportDag *DagExporter, dag *Dag) {
 		exportNode(exportedNode, node)
 		exportDag.Nodes[nodeId] = exportedNode
 	}
-}
-
-// GetPipelineDefinition generate pipeline DAG definition as a json
-func GetPipelineDefinition(pipeline *Pipeline) string {
-	root := &DagExporter{}
-
-	// Validate the dag
-	root.IsValid = true
-	err := pipeline.Dag.Validate()
-	if err != nil {
-		root.IsValid = false
-		root.ValidationError = err.Error()
-	}
-
-	exportDag(root, pipeline.Dag)
-	encoded, _ := json.MarshalIndent(root, "", "    ")
-	return string(encoded)
 }

--- a/core/sdk/exporter/exporter.go
+++ b/core/sdk/exporter/exporter.go
@@ -44,9 +44,10 @@ func (fexp *FlowExporter) Export() ([]byte, error) {
 		return nil, fmt.Errorf("Failed to define flow, %v", err)
 	}
 
-	definition := sdk.GetPipelineDefinition(fexp.flow)
+	// Get DAG json definition
+	definition, _ := fexp.flow.Dag.GetDefinitionJson()
 
-	return []byte(definition), nil
+	return definition, nil
 }
 
 // CreateFlowExporter initiate a FlowExporter with a provided Executor

--- a/flow/v1/workflow.go
+++ b/flow/v1/workflow.go
@@ -249,6 +249,14 @@ func (currentDag *Dag) Validate() error {
 	return currentDag.udag.Validate()
 }
 
+func (currentDag *Dag) Definition() (*sdk.DagExporter, error) {
+	return currentDag.udag.GetDefinition()
+}
+
+func (currentDag *Dag) DefinitionJson() ([]byte, error) {
+	return currentDag.udag.GetDefinitionJson()
+}
+
 // createWorkload Create a function with execution name
 func createWorkload(id string, mod operation.Modifier) *operation.GoFlowOperation {
 	operation := &operation.GoFlowOperation{}


### PR DESCRIPTION
This fixes #29 

Add two Apis 
```go
Definition() (*sdk.DagExporter, error)
DefinitionJson() ([]byte, error)
```

Json can be exported as 
```go
data, _  := dag.DefinitionJson()
fmt.Println(string(data))
```
